### PR TITLE
Allow providing alternative (more advanced) query string parsers

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,11 +15,13 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      "test/browser/**/*Spec.js"
+      "test/browser/**/*Spec.js",
+      "index.js"
     ],
 
     preprocessors: {
-      "test/browser/**/*Spec.js" : ["browserify"]
+      "test/browser/**/*Spec.js" : ["browserify"],
+      "index.js" : ["browserify"]
     },
 
     browserify: {

--- a/readme.md
+++ b/readme.md
@@ -399,3 +399,11 @@ routeInstance.a([options], contents, ...)
 ```
 
 Generates virtual DOM for an anchor for the route, passing the arguments to `h('a', options, contents, ...)`, but with the correct `href` and `onclick` properties set.
+
+### querystring
+
+If you need complex values in query string parameters (e.g. arrays), you can provide a query string library that supports that (e.g. [qs](https://www.npmjs.com/package/qs) or [querystring](https://nodejs.org/api/querystring.html))
+
+```js
+router.querystring = require('qs');
+```

--- a/test/browser/plastiqRouterSpec.js
+++ b/test/browser/plastiqRouterSpec.js
@@ -3,8 +3,9 @@ var h = plastiq.html;
 var router = require('../..');
 var browser = require('browser-monkey').scope('.test');
 var expect = require('chai').expect;
+var querystring = require('querystring');
 
-function describePlastiqRouter(apiName) {
+function describePlastiqRouter(apiName, qs) {
   describe('plastiq router ' + apiName, function () {
     var originalLocation;
     var api = router[apiName];
@@ -21,6 +22,10 @@ function describePlastiqRouter(apiName) {
       var options = apiName == 'historyApi'
         ? undefined
         : {history: api};
+
+      if (qs == 'querystring') {
+        router.querystring = querystring;
+      }
 
       router.start(options);
     });
@@ -523,7 +528,7 @@ function describePlastiqRouter(apiName) {
       expect(a({id: 'asdf', optional: 'yo'}).href).to.equal('/a/asdf?optional=yo');
     });
 
-    it('can return the href for a given route with params', function () {
+    it('can return the href for a given route with wildcard params', function () {
       var a = router.route('/a/:id/:path*');
       expect(a({id: 'asdf/qw er', path: 'a/b c/d', optional: 'yo'}).href).to.equal('/a/asdf%2Fqw%20er/a/b%20c/d?optional=yo');
     });
@@ -532,6 +537,7 @@ function describePlastiqRouter(apiName) {
 
 describePlastiqRouter('hash');
 describePlastiqRouter('historyApi');
+describePlastiqRouter('hash', 'querystring');
 
 function mount(render, model) {
   var div = document.createElement('div');


### PR DESCRIPTION
To support arrays in params for example.